### PR TITLE
Rename page RSS to RssHelper

### DIFF
--- a/en/views/helpers/rss.rst
+++ b/en/views/helpers/rss.rst
@@ -1,11 +1,11 @@
-RSS
-###
+RssHelper
+#########
 
 .. php:namespace:: Cake\View\Helper
 
 .. php:class:: RssHelper(View $view, array $config = [])
 
-The RSS helper makes generating XML for RSS feeds easy.
+The RSS helper makes generating XML for `RSS feeds <https://en.wikipedia.org/wiki/RSS>`_ easy.
 
 Creating an RSS Feed with the RssHelper
 =======================================


### PR DESCRIPTION
All other helper pages are called this way, only RSS stands out.

![bildschirmfoto 2015-02-02 um 11 01 12](https://cloud.githubusercontent.com/assets/6770775/5998715/d4f6ea3e-aaca-11e4-9f16-4456a6f0c579.png)
