### PR TITLE
Remove misleading example code

### DIFF
--- a/en/views/helpers.rst
+++ b/en/views/helpers.rst
@@ -122,12 +122,6 @@ your helper requires. For example::
                 'label' => '<label for="{{for}}">{{content}}</label>',
             ],
         ];
-
-        public function __construct(View $view, $config = [])
-        {
-            parent::__construct($view, $config);
-            $this->initStringTemplates();
-        }
     }
 
 Any configuration provided to your helper's constructor will be merged with the


### PR DESCRIPTION
`StringTemplateTrait::initStringTemplates()` is gone since https://github.com/cakephp/cakephp/commit/34a4dfa95fe226425a6ace4055c4c6218be03e71
